### PR TITLE
I've converted the Roman numeral converter to a Flask API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,44 @@
 
 ## Uso
 
+### Instalação de Dependências
+Para instalar as dependências necessárias, execute o seguinte comando:
 ```bash
-python roman_converter.py MCMLXXXI
+pip install -r requirements.txt
+```
+
+### Executando a Aplicação Flask
+Para iniciar o servidor Flask, execute:
+```bash
+python app.py
+```
+A API estará disponível em `http://127.0.0.1:5000`.
+
+### Exemplos de Uso da API
+
+Para converter um numeral romano para inteiro, use o endpoint `/romantointeger/<numeral_romano>`.
+
+Exemplo de sucesso:
+```bash
+curl http://127.0.0.1:5000/romantointeger/MCMLXXXI
+```
+Saída esperada:
+```json
+{
+  "integer": 1981
+}
+```
+
+Exemplo de numeral inválido:
+```bash
+curl http://127.0.0.1:5000/romantointeger/INVALID
+```
+Saída esperada:
+```json
+{
+  "details": "'I' is not a valid Roman numeral character.",
+  "error": "Invalid Roman numeral"
+}
 ```
 
 ## Testes

--- a/app.py
+++ b/app.py
@@ -1,0 +1,15 @@
+from flask import Flask, jsonify
+from roman_converter import roman_to_int
+
+app = Flask(__name__)
+
+@app.route('/romantointeger/<string:roman_numeral>', methods=['GET'])
+def convert_roman_to_integer(roman_numeral):
+    try:
+        result = roman_to_int(roman_numeral)
+        return jsonify({"integer": result}), 200
+    except ValueError as e:
+        return jsonify({"error": "Invalid Roman numeral", "details": str(e)}), 400
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/roman_converter.py
+++ b/roman_converter.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 def roman_to_int(s: str) -> int:
     # Função para verificar se o numeral romano é válido
@@ -38,15 +37,3 @@ def roman_to_int(s: str) -> int:
         prev_value = value
     
     return result
-
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Uso: python roman_converter.py <numeral_romano>")
-        sys.exit(1)
-    
-    numeral_romano = sys.argv[1]
-    try:
-        resultado = roman_to_int(numeral_romano)
-        print(f"O numeral romano {numeral_romano} equivale ao número {resultado}")
-    except ValueError as e:
-        print(e)

--- a/test_api.py
+++ b/test_api.py
@@ -1,0 +1,55 @@
+import unittest
+import requests
+import json
+
+# Define the base URL for the API
+BASE_URL = "http://127.0.0.1:5000"
+
+class TestRomanApi(unittest.TestCase):
+
+    def test_valid_roman_mcmlxxxi(self):
+        response = requests.get(f"{BASE_URL}/romantointeger/MCMLXXXI")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 1981}) # Corrected expected value
+
+    def test_valid_roman_iv(self):
+        response = requests.get(f"{BASE_URL}/romantointeger/IV")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 4})
+
+    def test_invalid_roman_input(self):
+        response = requests.get(f"{BASE_URL}/romantointeger/INVALID")
+        self.assertEqual(response.status_code, 400)
+        # We expect a specific error structure, but the details message can vary.
+        # So, we check for the presence of "error" and its value.
+        response_data = response.json()
+        self.assertIn("error", response_data)
+        self.assertEqual(response_data["error"], "Invalid Roman numeral")
+        self.assertIn("details", response_data) # Check if 'details' key is present
+
+    def test_edge_case_smallest_valid(self):
+        response = requests.get(f"{BASE_URL}/romantointeger/I")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 1})
+
+    def test_edge_case_largest_valid(self):
+        response = requests.get(f"{BASE_URL}/romantointeger/MMMCMXCIX")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 3999})
+
+    def test_valid_roman_mmxxi(self): # Added from original description, target was MCMLXXXI -> 1981
+        response = requests.get(f"{BASE_URL}/romantointeger/MMXXI")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 2021})
+
+    def test_valid_roman_mcmxciv(self): # Added to match original description for 1994
+        response = requests.get(f"{BASE_URL}/romantointeger/MCMXCIV")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"integer": 1994})
+
+
+if __name__ == '__main__':
+    # Note: For these tests to run, the Flask app (app.py) must be running separately.
+    # You can run the app using `python app.py` in one terminal,
+    # and then run these tests using `python -m unittest test_api.py` in another.
+    unittest.main()


### PR DESCRIPTION
This change introduces a Flask-based API for the Roman numeral conversion functionality.

Key changes:
- I added Flask and created an `app.py` with an API endpoint `/romantointeger/<roman_numeral>`.
- The endpoint converts Roman numerals to integers and returns JSON responses.
- It includes error handling for invalid Roman numerals (HTTP 400).
- I added `requirements.txt` with Flask and requests.
- I updated `README.md` with instructions for setting up and using the API.
- I added API tests in `test_api.py` using the `requests` library.
- I removed the old command-line interface from `roman_converter.py`.

The existing unit tests for the core conversion logic in `test_roman_converter.py` remain and pass.